### PR TITLE
Add `clone()` method

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ fastmap 1.1.0.9000
 
 * Changed `fastmap`'s `$has()` method to use C++ `contains()` method (which is new in hopscotch-map 2.3.0).
 
+* Closed #24: Added a `$clone()` method to `fastmap`. (#26)
+
 fastmap 1.1.0
 =============
 

--- a/R/fastmap.R
+++ b/R/fastmap.R
@@ -334,6 +334,22 @@ fastmap <- function(missing_default = NULL) {
     .Call(C_map_keys, key_idx_map, sort)
   }
 
+  clone <- function() {
+    m <- fastmap()
+    # Use this env to access internal objects of the new fastmap object.
+    e <- environment(m$get)
+    e$ensure_restore_map()
+
+    e$n           <- n
+    e$key_idx_map <- .Call(C_map_copy, key_idx_map)
+    e$keys_       <- keys_
+    e$values      <- values
+    e$holes       <- holes
+    e$n_holes     <- n_holes
+
+    m
+  }
+
   as_list <- function(sort = FALSE) {
     ensure_restore_map()
     keys_idxs <- .Call(C_map_keys_idxs, key_idx_map, sort)
@@ -429,6 +445,7 @@ fastmap <- function(missing_default = NULL) {
     remove = remove,
     keys = keys,
     size = size,
+    clone = clone,
     as_list = as_list
   )
 }

--- a/src/fastmap.cpp
+++ b/src/fastmap.cpp
@@ -213,6 +213,17 @@ extern "C" {
     return idxs;
   }
 
+  SEXP C_map_copy(SEXP map_xptr) {
+    SEXP new_map_xptr = C_map_create();
+    si_map* new_map = map_from_xptr(new_map_xptr);
+
+    si_map* map = map_from_xptr(map_xptr);
+
+    *new_map = *map;
+
+    return new_map_xptr;
+  }
+
   // Convert an R character vector to UTF-8. This is necessary because iconv
   // doesn't really work for vectors where the items have mixed encoding.
   SEXP C_char_vec_to_utf8(SEXP str) {

--- a/src/init.c
+++ b/src/init.c
@@ -6,6 +6,7 @@
 
 /* .Call calls */
 extern SEXP C_map_create();
+extern SEXP C_map_copy(SEXP);
 extern SEXP C_map_set(SEXP, SEXP, SEXP);
 extern SEXP C_map_get(SEXP, SEXP);
 extern SEXP C_map_has(SEXP, SEXP);
@@ -17,6 +18,7 @@ extern SEXP C_xptr_is_null(SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
   {"C_map_create",                  (DL_FUNC) &C_map_create,           0},
+  {"C_map_copy",                    (DL_FUNC) &C_map_copy,             1},
   {"C_map_set",                     (DL_FUNC) &C_map_set,              3},
   {"C_map_get",                     (DL_FUNC) &C_map_get,              2},
   {"C_map_has",                     (DL_FUNC) &C_map_has,              2},

--- a/tests/testthat/test-map.R
+++ b/tests/testthat/test-map.R
@@ -291,3 +291,21 @@ test_that("Stress test, compared to environment", {
     expect_mapequal(as.list(e), m$as_list())
   }
 })
+
+
+test_that("Cloning", {
+  m <- fastmap()
+  m$mset(a=1, b=2, c=3)
+
+  m1 <- m$clone()
+  expect_setequal(c("a", "b", "c"), m1$keys())
+  expect_mapequal(list(a=1, b=2, c=3), m1$as_list())
+
+  # Make sure the original and copy are independent.
+  m1$set("a", 10)
+  m1$remove("c")
+  m$set("a", 1000)
+  m$remove("b")
+  expect_mapequal(list(a=10, b=2), m1$as_list())
+  expect_mapequal(list(a=1000, c=3), m$as_list())
+})


### PR DESCRIPTION
Closes #24.

This is significantly faster than manual copying. For a million objects, it's about 0.14 seconds vs 3 seconds on my computer.


```R
library(fastmap)

rm(list=ls())
n <- 1e6
x <- seq_len(n)

m <- fastmap()
m$mset(.list = setNames(x, as.character(x)))


# stla's copy function
invisible(gc())
copy <- function(map) {
  fm <- fastmap()
  for(k in map$keys()) {
    fm$set(k, map$get(k))
  }
  fm
}
system.time({
  m2 <- copy(m)
})
#>    user  system elapsed 
#>   2.992   0.030   3.025


# clone() method
invisible(gc())
system.time({
  m4 <- m$clone()
})
#>    user  system elapsed 
#>   0.008   0.005   0.014
```