### PR TITLE
Fix `unserialize(serialize())` behavior when there are no holes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@ fastmap 1.1.0.9000
 
 * Closed #24: Added a `$clone()` method to `fastmap`. (#26)
 
+* Fixed #27: If a `fastmap` object has no holes in the lists storing keys and values, and then it is serialized and then unserialized, the new `fastmap` would contain zero items. (#28)
+
 fastmap 1.1.0
 =============
 

--- a/R/fastmap.R
+++ b/R/fastmap.R
@@ -431,8 +431,14 @@ fastmap <- function(missing_default = NULL) {
 
     # Repopulate key_idx_map.
     key_idx_map <<- .Call(C_map_create)
-    holes <- holes[seq_len(n_holes)]
-    idxs <- seq_along(keys_)[-holes]
+    if (n_holes == 0) {
+      # Need to special case when 0 holes, because x[-integer(0)] (as done in
+      # the other code path) returns an empty vector, instead of the original x.
+      idxs <- seq_along(keys_)
+    } else {
+      holes <- holes[seq_len(n_holes)]
+      idxs <- seq_along(keys_)[-holes]
+    }
     for (idx in idxs) {
       .Call(C_map_set, key_idx_map, keys_[idx], idx)
     }

--- a/tests/testthat/test-serialize.R
+++ b/tests/testthat/test-serialize.R
@@ -34,6 +34,19 @@ test_that("Serializing and unserializing a map", {
   expect_true(all(Encoding(m1$keys()) %in% c("unknown", "UTF-8")))
 })
 
+
+test_that("Serializing and unserializing fastmap with no holes", {
+  x <- seq_len(32)
+
+  m <- fastmap()
+  m$mset(.list = setNames(x, as.character(x)))
+  m1 <- unserialize(serialize(m, NULL))
+
+  expect_length(m1$as_list(), 32)
+  expect_mapequal(m$as_list(), m1$as_list())
+})
+
+
 test_that("Serializing and unserializing stress test", {
   set.seed(3524)
 


### PR DESCRIPTION
Closes #27.