### PR TITLE
Use `contains()` method

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 fastmap 1.1.1.9000
 =============
 
+* Changed `fastmap`'s `$has()` method to use C++ `contains()` method (which is new in hopscotch-map 2.3.0). (#30)
 
 fastmap 1.1.1
 =============

--- a/R/fastmap.R
+++ b/R/fastmap.R
@@ -278,8 +278,7 @@ fastmap <- function(missing_default = NULL) {
   # Internal function
   has_one <- function(key) {
     ensure_restore_map()
-    idx <- .Call(C_map_get, key_idx_map, key)
-    return(idx != -1L)
+    .Call(C_map_has, key_idx_map, key)
   }
 
   has <- function(keys) {


### PR DESCRIPTION
This should be merged at some point in the future, after we're confident that the vast majority of users have updated to the upcoming fastmap 1.1.1, which has hopscotch-map 2.3.0. See the commit message for 5eba9513196db6268845b1adcb823aa71b7b1008 for more information.


The NEWS file should have this added to it in the appropriate location:

```
* Changed `fastmap`'s `$has()` method to use C++ `contains()` method (which is new in hopscotch-map 2.3.0).
```