### PR TITLE
Allow `$mset()` to work with empty input

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fastmap
 Title: Fast Data Structures
-Version: 1.1.1.9000
+Version: 1.1.1.9001
 Authors@R: c(
     person("Winston", "Chang", email = "winston@posit.co", role = c("aut", "cre")),
     person(given = "Posit Software, PBC", role = c("cph", "fnd")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ fastmap 1.1.1.9000
 
 * Changed `fastmap`'s `$has()` method to use C++ `contains()` method (which is new in hopscotch-map 2.3.0). (#30)
 
+* Previously calling `$mset()` with empty input would result in an error; now it is a no-op. (#38)
+
 fastmap 1.1.1
 =============
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-fastmap 1.1.1.9000
+fastmap 1.1.1.9001
 =============
 
 * Changed `fastmap`'s `$has()` method to use C++ `contains()` method (which is new in hopscotch-map 2.3.0). (#30)

--- a/R/fastmap.R
+++ b/R/fastmap.R
@@ -238,6 +238,9 @@ fastmap <- function(missing_default = NULL) {
 
   mset <- function(..., .list = NULL) {
     objs <- c(list(...), .list)
+    if (length(objs) == 0) {
+      return(invisible(list(a=1)[0])) # Special case: return empty named list
+    }
     keys <- names(objs)
     if (is.null(keys) || any(is.na(keys)) || any(keys == "")) {
       stop("mset: all values must be named.")

--- a/tests/testthat/helpers-fastmap.R
+++ b/tests/testthat/helpers-fastmap.R
@@ -3,3 +3,9 @@
 env <- function(x) {
   environment(x$as_list)
 }
+
+# An empty named list is different from an empty unnamed list. This creates
+# the former.
+empty_named_list <- function() {
+  list(a=1)[0]
+}

--- a/tests/testthat/test-map.R
+++ b/tests/testthat/test-map.R
@@ -329,3 +329,22 @@ test_that("keys() implementation", {
   expect_setequal(m$keys(), c_keys(m))
   expect_identical(m$keys(TRUE), c_keys(m, TRUE))
 })
+
+
+test_that("mset() with empty input", {
+  m <- fastmap()
+
+  m$mset()
+  expect_identical(m$as_list(), empty_named_list())
+  m$mset(.list = character())
+  m$mset(.list = list())
+  m$mset(.list = empty_named_list())
+  expect_identical(m$as_list(), empty_named_list())
+
+  m$set("a", 1)
+  expect_identical(m$as_list(), list(a = 1))
+  m$mset(.list = character())
+  m$mset(.list = list())
+  m$mset(.list = empty_named_list())
+  expect_identical(m$as_list(), list(a = 1))
+})


### PR DESCRIPTION
Previously calling `$mset()` with empty input would result in an error; now it is a no-op.