### PR TITLE
Use radix sorting for order() in as_list()

### DIFF
--- a/R/fastmap.R
+++ b/R/fastmap.R
@@ -374,7 +374,7 @@ fastmap <- function(missing_default = NULL) {
     result <- values[idxs]
     names(result) <- keys_[idxs]
     if (sort) {
-      result <- result[order(names(result))]
+      result <- result[order(names(result), method = "radix")]
     }
     result
   }


### PR DESCRIPTION
The test suite broke as we tried updating 1.1.0 -> 1.2.0:

```
── Failure (test-map.R:247:3): Sorting keys ────────────────────────────────────
m$as_list(sort = TRUE) not identical to list(.d = 4, a = 1, b = 2, c = 3).
Names: 4 string mismatches
Component 1: Mean relative difference: 3
Component 2: Mean relative difference: 0.5
Component 3: Mean relative difference: 0.3333333
Component 4: Mean relative difference: 0.25
```

I'm not sure why this isn't showing up on CRAN or on your end. 

But I do see `method="radix"` under `sort` explicitly elsewhere, and this does make tests pass for me, so I think this is a good change regardless.